### PR TITLE
Add sound metadata CSV output

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/csv"
 	"fmt"
 	"io"
 	"log"
@@ -86,6 +87,16 @@ func readIndex(inbuf *bytes.Reader) {
 
 func readSounds(inbuf *bytes.Reader) {
 	os.Mkdir("out", 0755)
+
+	namesFile, err := os.Create("names.csv")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer namesFile.Close()
+	writer := csv.NewWriter(namesFile)
+	defer writer.Flush()
+	writer.Write([]string{"ID", "Offset", "Size", "Format", "NumMods", "ModNumber", "ModInit", "NumCommands", "Cmd", "Param1", "Param2", "Datapart"})
+
 	numItems := uint32(len(SoundLocationMap) - 1)
 
 	var z uint32
@@ -104,7 +115,22 @@ func readSounds(inbuf *bytes.Reader) {
 		var tmp SndListRes
 		binary.Read(inbuf, binary.BigEndian, &tmp)
 
-		for z := 0; z < int(snd.size); z++ {
+		writer.Write([]string{
+			fmt.Sprint(snd.id),
+			fmt.Sprint(snd.offset),
+			fmt.Sprint(snd.size),
+			fmt.Sprint(tmp.Format),
+			fmt.Sprint(tmp.NumMods),
+			fmt.Sprint(tmp.ModNumber),
+			fmt.Sprint(tmp.ModInit),
+			fmt.Sprint(tmp.NumCommands),
+			fmt.Sprint(tmp.Cmd),
+			fmt.Sprint(tmp.Param1),
+			fmt.Sprint(tmp.Param2),
+			fmt.Sprint(tmp.Datapart),
+		})
+
+		for i := 0; i < int(snd.size); i++ {
 			cTmp, err := inbuf.ReadByte()
 			if err != nil {
 				break


### PR DESCRIPTION
## Summary
- generate `names.csv` mapping sound IDs to their metadata
- keep sound dumps named by ID only

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898327b9e78832a8cb73470f3b45da5